### PR TITLE
Fix speech recognition language usage

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,6 +35,8 @@ io.on("connection", (socket) => {
   });
 
   const speechConfig = sdk.SpeechConfig.fromSubscription(process.env.AZURE_KEY, process.env.AZURE_REGION);
+  // Apply the input language selected by the client
+  speechConfig.speechRecognitionLanguage = inputLang;
   const audioConfig = sdk.AudioConfig.fromStreamInput(pushStream);
   const recognizer = new sdk.SpeechRecognizer(speechConfig, audioConfig);
 
@@ -93,10 +95,19 @@ async function synthesizeSpeech(text, langCode) {
   const audioConfig = sdk.AudioConfig.fromAudioFileOutput(`public/tts/${outputFile}`);
   const synthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
 
-  return new Promise((resolve) => {
-    synthesizer.speakTextAsync(text, () => {
-      resolve(`/tts/${outputFile}`);
-    });
+  return new Promise((resolve, reject) => {
+    synthesizer.speakTextAsync(
+      text,
+      () => {
+        synthesizer.close();
+        resolve(`/tts/${outputFile}`);
+      },
+      (err) => {
+        console.error("Speech synthesis error", err);
+        synthesizer.close();
+        reject(err);
+      }
+    );
   });
 }
 


### PR DESCRIPTION
## Summary
- respect guide's language selection when creating the recognizer
- properly close the speech synthesizer and report errors

## Testing
- `node --check server.js`
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6847102b36c0833183a9d8698aae12be